### PR TITLE
Restore test coverage for group.py.

### DIFF
--- a/loom/cFormat.pyx
+++ b/loom/cFormat.pyx
@@ -160,7 +160,6 @@ cdef class Row:
         cdef int i
         for i in range(self.ptr.pos().observed().dense_size()):
             yield self.ptr.pos().observed().dense(i)
-        raise StopIteration()
 
     def booleans_size(self):
         return self.ptr.pos().booleans_size()
@@ -175,7 +174,6 @@ cdef class Row:
         cdef int i
         for i in range(self.booleans_size()):
             yield self.booleans(i)
-        raise StopIteration()
 
     def counts_size(self):
         return self.ptr.pos().counts_size()
@@ -190,7 +188,6 @@ cdef class Row:
         cdef int i
         for i in range(self.counts_size()):
             yield self.counts(i)
-        raise StopIteration()
 
     def reals_size(self):
         return self.ptr.pos().reals_size()
@@ -205,7 +202,6 @@ cdef class Row:
         cdef int i
         for i in range(self.reals_size()):
             yield self.reals(i)
-        raise StopIteration()
 
     def dump(self):
         return {

--- a/loom/group.py
+++ b/loom/group.py
@@ -151,7 +151,7 @@ def find_consensus_grouping(groupings, debug=False):
 
     adjacency = [[] for _ in vertices]
     for i, j in edges:
-        adjacency[i].append(j)
+        adjacency[i].append(int(j))
 
     # FIXME is there a better way to choose the final group count?
     group_count = int(numpy.median(list(map(len, groupings_list))))

--- a/loom/test/test_group.py
+++ b/loom/test/test_group.py
@@ -38,6 +38,8 @@ from nose.tools import assert_almost_equal
 from nose.tools import assert_equal
 from nose.tools import assert_set_equal
 
+ROW_COUNT = 1000
+SAMPLE_COUNT = 10
 
 def test_metis():
 
@@ -69,20 +71,15 @@ def test_metis():
 
 
 class TestTypeIsCorrect:
-    def __init__(self):
-        ROW_COUNT = 1000
-        SAMPLE_COUNT = 10
-
-        self.clustering = distributions.lp.clustering.PitmanYor()
-        self.sample_count = SAMPLE_COUNT
-        self.row_ids = map(str, range(ROW_COUNT))
 
     def sample_grouping(self):
-        assignments = self.clustering.sample_assignments(len(self.row_ids))
-        return loom.group.collate(zip(assignments, self.row_ids))
+        row_ids = list(map(str, range(ROW_COUNT)))
+        clustering = distributions.lp.clustering.PitmanYor()
+        assignments = clustering.sample_assignments(len(row_ids))
+        return loom.group.collate(zip(assignments, row_ids))
 
     def sample_groupings(self):
-        return [self.sample_grouping() for _ in range(self.sample_count)]
+        return [self.sample_grouping() for _ in range(SAMPLE_COUNT)]
 
     def test_simple(self):
         groupings = self.sample_groupings()
@@ -92,13 +89,14 @@ class TestTypeIsCorrect:
             assert isinstance(row, loom.group.Row), row
 
         row_ids = set(row.row_id for row in grouping)
+        expected_row_ids = list(map(str, range(ROW_COUNT)))
         assert len(row_ids) == len(grouping), 'grouping had duplicate rows'
-        assert_set_equal(set(self.row_ids), row_ids)
+        assert_set_equal(set(expected_row_ids), row_ids)
 
         group_ids = sorted(list(set(row.group_id for row in grouping)))
         assert_equal(
             group_ids,
-            range(len(group_ids)),
+            list(range(len(group_ids))),
             'group ids were not a contiguous range of integers')
 
     def test_sorting(self):


### PR DESCRIPTION
This test was getting skipped earlier because the test class defined an `__init__` method, which is no longer supported.